### PR TITLE
Correctly record commands passed to Kill

### DIFF
--- a/command_runner/fake_command_runner/fake_command_runner.go
+++ b/command_runner/fake_command_runner/fake_command_runner.go
@@ -172,7 +172,7 @@ func (r *FakeCommandRunner) Kill(cmd *exec.Cmd) error {
 	r.Lock()
 	defer r.Unlock()
 
-	r.killedCommands = append(r.waitedCommands, cmd)
+	r.killedCommands = append(r.killedCommands, cmd)
 
 	return nil
 }
@@ -226,6 +226,13 @@ func (r *FakeCommandRunner) KilledCommands() []*exec.Cmd {
 	defer r.RUnlock()
 
 	return r.killedCommands
+}
+
+func (r *FakeCommandRunner) WaitedCommands() []*exec.Cmd {
+	r.RLock()
+	defer r.RUnlock()
+
+	return r.waitedCommands
 }
 
 func (r *FakeCommandRunner) SignalledCommands() map[*exec.Cmd]os.Signal {

--- a/command_runner/fake_command_runner/fake_command_runner_suite_test.go
+++ b/command_runner/fake_command_runner/fake_command_runner_suite_test.go
@@ -1,0 +1,13 @@
+package fake_command_runner_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestFakeCommandRunner(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "FakeCommandRunner Suite")
+}

--- a/command_runner/fake_command_runner/fake_command_runner_test.go
+++ b/command_runner/fake_command_runner/fake_command_runner_test.go
@@ -1,0 +1,52 @@
+package fake_command_runner_test
+
+import (
+	"github.com/cloudfoundry/gunk/command_runner/fake_command_runner"
+
+	"os/exec"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("FakeCommandRunner", func() {
+
+	var (
+		runner    *fake_command_runner.FakeCommandRunner
+		cmd, cmd2 *exec.Cmd
+	)
+
+	BeforeEach(func() {
+		runner = fake_command_runner.New()
+		cmd = &exec.Cmd{}
+		cmd2 = &exec.Cmd{}
+	})
+
+	Describe("Kill", func() {
+		It("should record Kill commands", func() {
+			runner.Kill(cmd)
+			Expect(runner.KilledCommands()).To(Equal([]*exec.Cmd{cmd}))
+		})
+
+		// This may seem like an odd test, but it exposed a bug.
+		It("should not confuse Kill and Wait", func() {
+			runner.Kill(cmd)
+			runner.Wait(cmd2)
+			Expect(runner.KilledCommands()).To(Equal([]*exec.Cmd{cmd}))
+		})
+	})
+
+	Describe("Wait", func() {
+		It("should record Wait commands", func() {
+			runner.Wait(cmd)
+			Expect(runner.WaitedCommands()).To(Equal([]*exec.Cmd{cmd}))
+		})
+
+		It("should not confuse Wait and Kill", func() {
+			runner.Wait(cmd)
+			runner.Kill(cmd2)
+			Expect(runner.WaitedCommands()).To(Equal([]*exec.Cmd{cmd}))
+		})
+	})
+
+})


### PR DESCRIPTION
This fixes gunk issue #3: "Kill adds waited commands to the list of
killed commands". As part of fixing this, created the beginnings of a
test suite for `fake_command_runner`.

Rather than delete the unused list of waited commands, added a
`WaitedCommands` method.
